### PR TITLE
Fixed the variable to for the map object

### DIFF
--- a/src/controllers/customer.ts
+++ b/src/controllers/customer.ts
@@ -58,7 +58,7 @@ export const getProfile: (req: Request, res: Response) => void = async (
         InvocationType: "RequestResponse",
         Payload: JSON.stringify({
           Function: "getNotifications",
-          Payload: authStatus["body"],
+          Payload: authStatus["payload"],
         }),
       })
       .promise();


### PR DESCRIPTION
The variable in our lambda invocation needed to be changed from "body" to "payload" for the go lambda function to handle the request.